### PR TITLE
Update libphonenumber-js version to 1.11.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,4 +19,4 @@ lazy val scalaPhoneNumber =
     )
     .jvmSettings(libraryDependencies += "com.googlecode.libphonenumber" % "libphonenumber" % "8.13.38")
     .jsConfigure(_.enablePlugins(ScalaJSBundlerPlugin))
-    .jsSettings(Compile / npmDependencies += "libphonenumber-js" -> "1.9.47")
+    .jsSettings(Compile / npmDependencies += "libphonenumber-js" -> "1.11.3")


### PR DESCRIPTION
In the build.sbt file, the version of the libphonenumber-js dependency has been updated from 1.9.47 to 1.11.3. This is part of regular maintenance and keeping up-to-date with library versions.
