### PR TITLE
Add Metals-related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.log
 target/
 .idea/
+.bloop/
+.bsp/
+.metals/
+.vscode/
+metals.sbt


### PR DESCRIPTION
Several Metals-related files and directories have been added to .gitignore. This includes the .bloop, .bsp, .metals, .vscode directories, and the metals.sbt file. This commit ensures that these development tool files are not tracked in Git.
