### PR TITLE
ci.sbt: Use wildcards for scala versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.15, 3.5.2]
+        scala: [2.x, 3.x]
         java: [zulu@8]
     runs-on: ${{ matrix.os }}
     steps:
@@ -85,22 +85,22 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Download target directories (2.13.15)
+      - name: Download target directories (2.x)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-2.13.15-${{ matrix.java }}
+          name: target-${{ matrix.os }}-2.x-${{ matrix.java }}
 
-      - name: Inflate target directories (2.13.15)
+      - name: Inflate target directories (2.x)
         run: |
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (3.5.2)
+      - name: Download target directories (3.x)
         uses: actions/download-artifact@v4
         with:
-          name: target-${{ matrix.os }}-3.5.2-${{ matrix.java }}
+          name: target-${{ matrix.os }}-3.x-${{ matrix.java }}
 
-      - name: Inflate target directories (3.5.2)
+      - name: Inflate target directories (3.x)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,8 +6,8 @@ pull_request_rules:
   - name: Automatically merge successful Scala Steward PRs
     conditions:
       - author=scala-steward
-      - check-success=Build and Test (ubuntu-latest, 2.13.15, zulu@8)
-      - check-success=Build and Test (ubuntu-latest, 3.5.2, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 2.x, zulu@8)
+      - check-success=Build and Test (ubuntu-latest, 3.x, zulu@8)
     actions:
         queue:
             name: default

--- a/ci.sbt
+++ b/ci.sbt
@@ -1,12 +1,12 @@
 val repoPath = "nafg/scala-phonenumber"
 inThisBuild(
   List(
-    homepage                            := Some(url(s"https://github.com/$repoPath")),
-    licenses                            := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
-    developers                          := List(
+    homepage                    := Some(url(s"https://github.com/$repoPath")),
+    licenses                    := List("Apache-2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0")),
+    developers                  := List(
       Developer("nafg", "Naftoli Gugenheim", "98384+nafg@users.noreply.github.com", url("https://github.com/nafg"))
     ),
-    scmInfo                             := Some(
+    scmInfo                     := Some(
       ScmInfo(
         browseUrl = url(s"https://github.com/$repoPath"),
         connection = s"scm:git:git://github.com/$repoPath.git",
@@ -14,7 +14,8 @@ inThisBuild(
       )
     ),
     dynverGitDescribeOutput ~= (_.map(o => o.copy(dirtySuffix = sbtdynver.GitDirtySuffix("")))),
-    dynverSonatypeSnapshots             := true,
+    dynverSonatypeSnapshots     := true,
+    githubWorkflowScalaVersions := githubWorkflowScalaVersions.value.map(_.replaceFirst("""\d+(\.\d+)?$""", "x")),
     githubWorkflowTargetTags ++= Seq("v*"),
     githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v"))),
     githubWorkflowPublish               := Seq(


### PR DESCRIPTION
This way, .mergify.yml won't need to be updated every time a new version is released.

This should also reduce merge conflicts.
