### PR TITLE
Update libphonenumber-js to version 1.11.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val scalaPhoneNumber =
     .jvmSettings(libraryDependencies += "com.googlecode.libphonenumber" % "libphonenumber" % "8.13.49")
     .jsEnablePlugins(ScalaJSBundlerPlugin, ScalablyTypedConverterGenSourcePlugin)
     .jsSettings(
-      Compile / npmDependencies += "libphonenumber-js" -> "1.11.3",
+      Compile / npmDependencies += "libphonenumber-js" -> "1.11.12",
       stOutputPackage                                  := "io.github.nafg.scalaphonenumber.facade",
       stMinimize                                       := Selection.AllExcept("libphonenumber-js")
     )


### PR DESCRIPTION
This change upgrades the libphonenumber-js npm dependency from version 1.11.3 to 1.11.12 in the build.sbt file.
